### PR TITLE
Add ability to reseed Chance generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ factory.define('user', User, {
   // seq is an alias for sequence
   email: factory.seq('User.email', (n) => `user${n}@ymail.com`),
 
-  // use the chance(http://chancejs.com/) library to generate real-life like data
+  // use the chance(http://chancejs.com/) library to generate
+  // real-life like data.
+  // For repeatable results, call factory.chance.seed(<value>) first.
   about: factory.chance('sentence'),
 
   // use assoc to associate with other models

--- a/src/generators/ChanceGenerator.js
+++ b/src/generators/ChanceGenerator.js
@@ -1,17 +1,24 @@
 import Chance from 'chance'
 import Generator from './Generator'
 
-const chance = new Chance()
-
 export default class ChanceGenerator extends Generator {
+  constructor(factoryGirl, seedValue) {
+    super(factoryGirl)
+    this.seed(seedValue)
+  }
+
+  seed(value) {
+    this.chance = new Chance(value)
+  }
+
   generate(chanceMethod, ...options) {
     if (typeof chanceMethod === 'function') {
-      return chanceMethod(chance, ...options)
+      return chanceMethod(this.chance, ...options)
     }
 
-    if (typeof chance[chanceMethod] !== 'function') {
+    if (typeof this.chance[chanceMethod] !== 'function') {
       throw new TypeError('Invalid chance method requested')
     }
-    return chance[chanceMethod](...options)
+    return this.chance[chanceMethod](...options)
   }
 }

--- a/test/FactoryGirlSpec.js
+++ b/test/FactoryGirlSpec.js
@@ -744,4 +744,18 @@ describe('FactoryGirl', () => {
       })
     })
   })
+  describe('#chance', () => {
+    const factoryGirl = new FactoryGirl()
+    it('follows a seed', () => {
+      const makeName = factoryGirl.chance('word')
+
+      factoryGirl.chance.seed(42)
+      const firstWords = new Array(5).fill().map(makeName)
+
+      factoryGirl.chance.seed(42)
+      const secondWords = new Array(5).fill().map(makeName)
+
+      expect(firstWords).to.deep.equal(secondWords)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds the ability to set the seed for the Chance generator:

```javascript
const factory = require('factory-bot').factory
factory.chance.seed(42)
```

thus allowing for repeatable results when generating realistic fake data.