### PR TITLE
inherit buildOptions in extended factories

### DIFF
--- a/src/FactoryGirl.js
+++ b/src/FactoryGirl.js
@@ -58,6 +58,7 @@ export default class FactoryGirl {
     }
     const parentFactory = this.getFactory(parent, true)
     const Model = options.model || parentFactory.Model
+    const jointOptions = { ...parentFactory.options, ...options }
     let jointInitializer
 
     function resolveInitializer(initializer, buildOptions) {
@@ -88,7 +89,7 @@ export default class FactoryGirl {
     const factory = (this.factories[name] = new Factory(
       Model,
       jointInitializer,
-      options,
+      jointOptions,
     ))
     return factory
   }
@@ -101,11 +102,10 @@ export default class FactoryGirl {
     const adapter = this.getAdapter(name)
     return this.getFactory(name)
       .build(adapter, attrs, buildOptions)
-      .then(
-        model =>
-          (this.options.afterBuild
-            ? this.options.afterBuild(model, attrs, buildOptions)
-            : model),
+      .then(model =>
+        (this.options.afterBuild
+          ? this.options.afterBuild(model, attrs, buildOptions)
+          : model),
       )
   }
 
@@ -114,11 +114,10 @@ export default class FactoryGirl {
     return this.getFactory(name)
       .create(adapter, attrs, buildOptions)
       .then(createdModel => this.addToCreatedList(adapter, createdModel))
-      .then(
-        model =>
-          (this.options.afterCreate
-            ? this.options.afterCreate(model, attrs, buildOptions)
-            : model),
+      .then(model =>
+        (this.options.afterCreate
+          ? this.options.afterCreate(model, attrs, buildOptions)
+          : model),
       )
   }
 
@@ -130,15 +129,14 @@ export default class FactoryGirl {
     const adapter = this.getAdapter(name)
     return this.getFactory(name)
       .buildMany(adapter, num, attrs, buildOptions)
-      .then(
-        models =>
-          (this.options.afterBuild
-            ? Promise.all(
-              models.map(model =>
-                this.options.afterBuild(model, attrs, buildOptions),
-              ),
-            )
-            : models),
+      .then(models =>
+        (this.options.afterBuild
+          ? Promise.all(
+            models.map(model =>
+              this.options.afterBuild(model, attrs, buildOptions),
+            ),
+          )
+          : models),
       )
   }
 
@@ -147,15 +145,14 @@ export default class FactoryGirl {
     return this.getFactory(name)
       .createMany(adapter, num, attrs, buildOptions)
       .then(models => this.addToCreatedList(adapter, models))
-      .then(
-        models =>
-          (this.options.afterCreate
-            ? Promise.all(
-              models.map(model =>
-                this.options.afterCreate(model, attrs, buildOptions),
-              ),
-            )
-            : models),
+      .then(models =>
+        (this.options.afterCreate
+          ? Promise.all(
+            models.map(model =>
+              this.options.afterCreate(model, attrs, buildOptions),
+            ),
+          )
+          : models),
       )
   }
 

--- a/test/FactoryGirlSpec.js
+++ b/test/FactoryGirlSpec.js
@@ -93,6 +93,24 @@ describe('FactoryGirl', () => {
       }
       expect(nameRepeated).to.throw(Error)
     })
+    it('inherits buildOptions', async () => {
+      const spy = sinon.spy()
+      const dummyBuildOptions = { afterBuild: spy }
+      factoryGirl.define(
+        'parentWithAfterBuild',
+        Object,
+        {
+          parent: true,
+        },
+        dummyBuildOptions,
+      )
+      factoryGirl.extend('parentWithAfterBuild', 'childWithParentAfterBuild', {
+        child: true,
+        override: 'child',
+      })
+      await factoryGirl.build('childWithParentAfterBuild')
+      expect(spy).to.have.been.calledOnce
+    })
     it('can extend with an initializer function', async () => {
       factoryGirl.define('parentWithObjectInitializer', Object, {
         parent: true,


### PR DESCRIPTION
Probably the solution to: https://github.com/simonexmachina/factory-girl/issues/134

- Given a parentFactory defined with buildOptions with its respective callbacks.
- Given a childFactory that extends that parentFactory.
- Whenever a models is built out of the aforementioned childFactory,
- the callbacks defined in the parentFactory are not being called.
```
const parentFactory = FactoryGirl.define('parent', Model, initializer, buildOptions);
const childFactory = FactoryGirl.extend('parent', 'child');

// whenever we build a childFactory, i.e.
await FactoryGirl.build('child');
// the `afterBuild`, and `afterCreate` callbacks set in parentFactory are not being called
```
This PR aims to solve this.
(the linter run at the pre commit hook added some style changes).