### PR TITLE
stop seeding chance with undefined

### DIFF
--- a/src/generators/ChanceGenerator.js
+++ b/src/generators/ChanceGenerator.js
@@ -4,7 +4,12 @@ import Generator from './Generator'
 export default class ChanceGenerator extends Generator {
   constructor(factoryGirl, seedValue) {
     super(factoryGirl)
-    this.seed(seedValue)
+
+    if (seedValue) {
+      this.seed(seedValue)
+    } else {
+      this.chance = new Chance()
+    }
   }
 
   seed(value) {

--- a/test/FactoryGirlSpec.js
+++ b/test/FactoryGirlSpec.js
@@ -775,5 +775,12 @@ describe('FactoryGirl', () => {
 
       expect(firstWords).to.deep.equal(secondWords)
     })
+    it('does not follow a seed when none is provided', () => {
+      const makeName = factoryGirl.chance('word')
+      const setSeedWords = ['wunruk', 'lihcug', 'atpik', 'cecbetzav', 'notpodop']
+
+      const randomWords = new Array(5).fill().map(makeName)
+      expect(randomWords).to.not.deep.equal(setSeedWords)
+    })
   })
 })


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/ratson/factory-bot/pull/2

It turns out, `chancejs` treats `undefined` as a valid value to seed data from. The change introduced in https://github.com/ratson/factory-bot/pull/2 means that, if a seed value is _not_ provided, a stable seed value is still used (`undefined`), instead of it being truly random.

I've restored the previous functionality, which will now initialize a new instance of `Chance` without a seed value, if no seed value is provided. 

The unit test I added shows the "stable" nature of the previous implementation - if you take out my change, you will _always_ get those 5 words first, as they are seeded by `undefined`. 